### PR TITLE
add formatter settings for editing Xtend files in Eclipse.

### DIFF
--- a/formatting/eclipse-xtend-formatter.xml
+++ b/formatting/eclipse-xtend-formatter.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<profiles version="1">
+<profile kind="XtendFormatterProfile" name="Test-Editor" version="1">
+<setting id="keep.one.line.methods" value="true"/>
+<setting id="line.width.max" value="120"/>
+<setting id="line.separator" value="&#10;"/>
+<setting id="braces.in.new.line" value="false"/>
+<setting id="newline.after.constructor.annotations" value="false"/>
+<setting id="blank.lines.between.classes" value="1"/>
+<setting id="blank.lines.after.packagedecl" value="1"/>
+<setting id="blank.lines.after.last.member" value="0"/>
+<setting id="blank.line.around.expressions" value="0"/>
+<setting id="indentation.length" value="-1"/>
+<setting id="newline.after.field.annotations" value="false"/>
+<setting id="newline.after.parameter.annotations" value="false"/>
+<setting id="blank.lines.between.imports" value="0"/>
+<setting id="indentation" value="&#9;"/>
+<setting id="tab.width" value="4"/>
+<setting id="whitespace.between.keyword.and.parenthesis" value="true"/>
+<setting id="blank.lines.before.first.member" value="0"/>
+<setting id="preserve.new.lines" value="true"/>
+<setting id="blank.lines.between.fields" value="0"/>
+<setting id="blank.lines.between.fields.and.methods" value="1"/>
+<setting id="blank.lines.after.imports" value="1"/>
+<setting id="newline.after.method.annotations" value="false"/>
+<setting id="blank.lines.between.methods" value="1"/>
+<setting id="blank.lines.between.enum.literals" value="0"/>
+<setting id="newline.after.class.annotations" value="false"/>
+<setting id="preserve.blank.lines" value="1"/>
+</profile>
+</profiles>

--- a/formatting/eclipse-xtend-formatter.xml
+++ b/formatting/eclipse-xtend-formatter.xml
@@ -1,31 +1,31 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <profiles version="1">
-<profile kind="XtendFormatterProfile" name="Test-Editor" version="1">
-<setting id="keep.one.line.methods" value="true"/>
-<setting id="line.width.max" value="120"/>
-<setting id="line.separator" value="&#10;"/>
-<setting id="braces.in.new.line" value="false"/>
-<setting id="newline.after.constructor.annotations" value="false"/>
-<setting id="blank.lines.between.classes" value="1"/>
+<profile kind="XtendFormatterProfile" name="Default [built-in + 150]" version="1">
 <setting id="blank.lines.after.packagedecl" value="1"/>
-<setting id="blank.lines.after.last.member" value="0"/>
+<setting id="blank.lines.after.last.member" value="1"/>
 <setting id="blank.line.around.expressions" value="0"/>
-<setting id="indentation.length" value="-1"/>
-<setting id="newline.after.field.annotations" value="false"/>
-<setting id="newline.after.parameter.annotations" value="false"/>
+<setting id="blank.lines.after.imports" value="1"/>
 <setting id="blank.lines.between.imports" value="0"/>
+<setting id="newline.after.method.annotations" value="true"/>
 <setting id="indentation" value="&#9;"/>
 <setting id="tab.width" value="4"/>
 <setting id="whitespace.between.keyword.and.parenthesis" value="true"/>
-<setting id="blank.lines.before.first.member" value="0"/>
-<setting id="preserve.new.lines" value="true"/>
-<setting id="blank.lines.between.fields" value="0"/>
-<setting id="blank.lines.between.fields.and.methods" value="1"/>
-<setting id="blank.lines.after.imports" value="1"/>
-<setting id="newline.after.method.annotations" value="false"/>
+<setting id="blank.lines.before.first.member" value="1"/>
 <setting id="blank.lines.between.methods" value="1"/>
+<setting id="indentation.length" value="-1"/>
+<setting id="keep.one.line.methods" value="true"/>
+<setting id="newline.after.field.annotations" value="false"/>
 <setting id="blank.lines.between.enum.literals" value="0"/>
-<setting id="newline.after.class.annotations" value="false"/>
+<setting id="preserve.new.lines" value="true"/>
+<setting id="newline.after.parameter.annotations" value="false"/>
+<setting id="line.width.max" value="150"/>
+<setting id="line.separator" value="&#10;"/>
+<setting id="braces.in.new.line" value="false"/>
+<setting id="newline.after.class.annotations" value="true"/>
+<setting id="newline.after.constructor.annotations" value="true"/>
+<setting id="blank.lines.between.fields" value="0"/>
 <setting id="preserve.blank.lines" value="1"/>
+<setting id="blank.lines.between.fields.and.methods" value="1"/>
+<setting id="blank.lines.between.classes" value="1"/>
 </profile>
 </profiles>


### PR DESCRIPTION
* correspond to the default settings, except in one single regard: whitespace.between.keyword.and.parenthesis is set to true here.